### PR TITLE
Add EPAM Services and Client Work Navigation Test

### DIFF
--- a/tests/epamservicesclient_work.spec.ts
+++ b/tests/epamservicesclient_work.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+test('EPAM Services and Client Work Navigation', async ({ page }) => {
+  // Navigate to the EPAM homepage
+  await page.goto('https://www.epam.com/');
+
+  // Select "Services" from the header menu
+  await page.click('text=Services');
+
+  // Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Verify that the "Client Work" text is visible on the page
+  await expect(page.locator('text=Client Work')).toBeVisible();
+});


### PR DESCRIPTION
This pull request adds a new Playwright test scenario for navigating through EPAM's Services and Client Work pages.

The test performs the following steps:
1. Navigates to the EPAM homepage
2. Selects "Services" from the header menu
3. Clicks the "Explore Our Client Work" link
4. Verifies that the "Client Work" text is visible on the page

This test will help ensure that the navigation to the Client Work page through the Services menu is functioning correctly.